### PR TITLE
make social preview image showup full size

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ layout: "which template to use"
 emoji: "[optional] for insertion to favicon"
 description: "[optional] for opengraph metadata"
 socialImage: "[optional] for opengraph metadata (external link or path to file)"
+socialImageAlt: "[optional] alt text describing social preview image, if you do not include this then it will fallback to the default image / alt"
 ```
 
 ### cache busting

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## breathe-easy.uk
 
-Website under construction.
+Website under construction
 
 ## notes
 

--- a/src/_data/defaultMeta.json
+++ b/src/_data/defaultMeta.json
@@ -1,5 +1,6 @@
 {
   "title": "Breathe Easy Sheffield",
   "description": "An eclectic series of Covid safer social & cultural events, designed with enhanced safety measures in place to reduce transmission risk. Launching autumn 2024.",
-  "image": "/static/img/ogimage-default.png"
+  "image": "/static/img/ogimage-default.png",
+  "imageAlt": "Breath Easy's logo"
 }

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -39,6 +39,7 @@
       content="{{  defaultMeta.image | absoluteUrl  }}"
     />
     {% endif %}
+    <meta name="twitter:card" content="summary_large_image" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="theme-color" content="#044156" />

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -39,8 +39,9 @@
       content="{{  defaultMeta.image | absoluteUrl  }}"
     />
     {% endif %}
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
     <meta name="theme-color" content="#044156" />
-    <title>{{ title }}</title>
     <link data-asset-hash href="/css/styles.css" rel="stylesheet" />
   </head>
   <body>

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -31,13 +31,15 @@
       property="og:description"
       content="{% withDefault description, defaultMeta.description  %}"
     />
-    {% if socialImage %}
+    {% if socialImage and socialImageAlt %}
     <meta property="og:image" content="{{  socialImage | absoluteUrl  }}" />
+    <meta property="og:image:alt" content="{{  socialImageAlt }}" />
     {% else %}
     <meta
       property="og:image"
       content="{{  defaultMeta.image | absoluteUrl  }}"
     />
+    <meta property="og:image:alt" content="{{  defaultMeta.imageAlt }}" />
     {% endif %}
     <meta name="twitter:card" content="summary_large_image" />
     <meta property="og:image:width" content="1200" />

--- a/src/_includes/base.html
+++ b/src/_includes/base.html
@@ -42,8 +42,6 @@
     <meta property="og:image:alt" content="{{  defaultMeta.imageAlt }}" />
     {% endif %}
     <meta name="twitter:card" content="summary_large_image" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
     <meta name="theme-color" content="#044156" />
     <link data-asset-hash href="/css/styles.css" rel="stylesheet" />
   </head>


### PR DESCRIPTION
before / after

![2024-07-04-15:33:01-screenshot](https://github.com/breathe-easy-events/breathe-easy.uk/assets/6824891/3fb16566-02e9-4b28-8127-88cea14cab6c)

twitter specific metadata made the difference. also add enforces alt text.